### PR TITLE
link fix in README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/niryariv/opentaba-server.png?branch=master)](https://travis-ci.org/niryariv/opentaba-server)
 
-This is the server part for http://niryariv.github.com/opentaba-client
+This is the server part for http://github.com/niryariv/opentaba-client
 
 The code is Flask based, working with MongoDB as database, Uses redis to handle queue. written to run on Heroku.
 


### PR DESCRIPTION
Incorrect link in README.md , link should point to source code and not to an instance.